### PR TITLE
Money-handling Gem and Sock views-updates + navbar updates to reflect this

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'puma'
 gem 'rails', '5.2.4.1'
 gem 'redis'
 gem 'devise'
+gem 'money-rails', '~>1.12'
 
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass', '~> 5.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,15 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
+    monetize (1.9.4)
+      money (~> 6.12)
+    money (6.13.7)
+      i18n (>= 0.6.4, <= 2)
+    money-rails (1.13.3)
+      activesupport (>= 3.0)
+      monetize (~> 1.9.0)
+      money (~> 6.13.2)
+      railties (>= 3.0)
     msgpack (1.3.1)
     nio4r (2.5.2)
     nokogiri (1.10.7)
@@ -198,6 +207,7 @@ DEPENDENCIES
   font-awesome-sass (~> 5.6.1)
   jbuilder (~> 2.0)
   listen (~> 3.0.5)
+  money-rails (~> 1.12)
   pg (~> 0.21)
   pry-byebug
   pry-rails
@@ -216,4 +226,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/controllers/socks_controller.rb
+++ b/app/controllers/socks_controller.rb
@@ -1,5 +1,5 @@
 class SocksController < ApplicationController
-  skip_before_action :authenticate_user!, only: :index
+  skip_before_action :authenticate_user!, only: [:index, :show]
   def index
     if current_user
       @my_socks = current_user.socks

--- a/app/models/sock.rb
+++ b/app/models/sock.rb
@@ -5,6 +5,6 @@ class Sock < ApplicationRecord
   validates :textile, presence: true
   validates :color, presence: true
   validates :size, presence: true, numericality: { only_integer: true }
-  validates :price, presence: true, numericality: { only_integer: true }
+  monetize :price_cents, numericality: { greater_than_or_equal_to: 0 }
   validates :status, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :funds, greater_than_or_equal_to: 0
+  validates :funds, numericality: { greater_than_or_equal_to: 0 }
   has_many :socks
   has_many :bookings
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :funds, numericality: { greater_than_or_equal_to: 0 }
   has_many :socks
   has_many :bookings
+  monetize :funds_cents, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  validates :funds, greater_than_or_equal_to: 0
   has_many :socks
   has_many :bookings
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -15,10 +15,10 @@
           <%= link_to "Home", "root_path", class: "nav-link" %>
         </li>
         <li class="nav-item">
-          <%= link_to "Messages", "#", class: "nav-link" %>
+          <%= link_to "€#{current_user.funds}", "#", class: "nav-link" %>
         </li>
         <li class="nav-item">
-          <%= link_to "€#{current_user.funds}", "#", class: "nav-link" %>
+          <%= link_to "#{current_user.email}", "#", class: "nav-link" %>
         </li>
         <li class="nav-item dropdown">
           <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -17,6 +17,9 @@
         <li class="nav-item">
           <%= link_to "Messages", "#", class: "nav-link" %>
         </li>
+        <li class="nav-item">
+          <%= link_to "€#{current_user.funds}", "#", class: "nav-link" %>
+        </li>
         <li class="nav-item dropdown">
           <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -14,8 +14,8 @@
         <li class="nav-item active">
           <%= link_to "Home", "root_path", class: "nav-link" %>
         </li>
-        <li class="nav-item">
-          <%= link_to "€#{current_user.funds}", "#", class: "nav-link" %>
+        <li class="nav-item currency_symbol">
+          <%= link_to "#{current_user.funds.symbol} #{current_user.funds}", "#", class: "nav-link" %>
         </li>
         <li class="nav-item">
           <%= link_to "#{current_user.email}", "#", class: "nav-link" %>

--- a/app/views/shared/_new_edit_sock.html.erb
+++ b/app/views/shared/_new_edit_sock.html.erb
@@ -1,11 +1,13 @@
-<%= form_for(@sock) do |f| %>
-  <p><%= f.label :textile %></p>
-  <p><%= f.text_field :textile %></p>
-  <p><%= f.label :color %></p>
-  <p><%= f.text_field :color %></p>
-  <p><%= f.label :size %></p>
-  <p><%= f.text_field :size %></p>
-  <p><%= f.label :price %> in <%= @sock.price.symbol %></p>
-  <p><%= f.text_field :price %></p>
-  <%= f.submit %>
-<% end %>
+<div class="container">
+  <%= form_for(@sock) do |f| %>
+    <p><%= f.label :textile %></p>
+    <p><%= f.text_field :textile %></p>
+    <p><%= f.label :color %></p>
+    <p><%= f.text_field :color %></p>
+    <p><%= f.label :size %></p>
+    <p><%= f.text_field :size %></p>
+    <p><%= f.label :price %> in <%= @sock.price.symbol %></p>
+    <p><%= f.text_field :price %></p>
+    <%= f.submit %>
+  <% end %>
+</div>

--- a/app/views/shared/_new_edit_sock.html.erb
+++ b/app/views/shared/_new_edit_sock.html.erb
@@ -5,7 +5,7 @@
   <p><%= f.text_field :color %></p>
   <p><%= f.label :size %></p>
   <p><%= f.text_field :size %></p>
-  <p><%= f.label :price %></p>
+  <p><%= f.label :price %> in <%= @sock.price.symbol %></p>
   <p><%= f.text_field :price %></p>
   <%= f.submit %>
 <% end %>

--- a/app/views/socks/edit.html.erb
+++ b/app/views/socks/edit.html.erb
@@ -1,1 +1,2 @@
+<div class="container"><h3><b>Edit this sock:</b></h3></div>
 <%= render 'shared/new_edit_sock', sock: @sock %>

--- a/app/views/socks/index.html.erb
+++ b/app/views/socks/index.html.erb
@@ -1,19 +1,22 @@
 <div class="container">
-  <h1>Socks for sale!</h1>
-    <div class="sock_card">
-      <% @my_socks.each do |sock| %>
-        <% if sock.status != 'hidden' %>
-          <h3><strong>Textile</strong> : <%= sock.textile %></h3>
-          <p><strong>Color</strong> : <%= sock.color %></p>
-          <p><strong>Size</strong> : <%= sock.size %></p>
-          <p><strong>Price</strong> : <%= sock.price %></p>
-          <button type="button" class="btn_small">  <%= link_to 'Show sock', sock_path(sock), method: :get%> </button>
-          <button type="button" class="btn_small">  <%= link_to 'Edit sock', edit_sock_path(sock), method: :get%> </button>
-          <br>
-          <br>
+  <h1>Marketplace:</h1>
+    <% if @my_socks != [] %>
+      <h3><b>My Socks:</b></h3>
+      <div class="sock_card">
+        <% @my_socks.each do |sock| %>
+          <% if sock.status == 'active' %>
+            <h3><strong>Textile</strong> : <%= sock.textile %></h3>
+            <p><strong>Color</strong> : <%= sock.color %></p>
+            <p><strong>Size</strong> : <%= sock.size %></p>
+            <p><strong>Price</strong> : <%= sock.price %></p>
+            <button type="button" class="btn_small">  <%= link_to 'Show sock', sock_path(sock), method: :get%> </button>
+            <button type="button" class="btn_small">  <%= link_to 'Edit sock', edit_sock_path(sock), method: :get%> </button>
+            <br>
+            <br>
+          <% end %>
         <% end %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
 
       <br>
       <br>
@@ -21,11 +24,14 @@
 
       <div class="sock_card">
         <% @socks.each do |sock| %>
-          <% if sock.status != 'hidden' %>
+          <% if sock.status == 'active' %>
             <h3><strong>Textile</strong> : <%= sock.textile %></h3>
             <p><strong>Color</strong> : <%= sock.color %></p>
             <p><strong>Size</strong> : <%= sock.size %></p>
             <p><strong>Price</strong> : <%= sock.price %></p>
+            <button type="button" class="btn_small">  <%= link_to 'Show sock', sock_path(sock), method: :get%> </button>
+            <br>
+            <br>
           <% end %>
         <% end %>
       </div>

--- a/app/views/socks/index.html.erb
+++ b/app/views/socks/index.html.erb
@@ -8,7 +8,7 @@
             <h3><strong>Textile</strong> : <%= sock.textile %></h3>
             <p><strong>Color</strong> : <%= sock.color %></p>
             <p><strong>Size</strong> : <%= sock.size %></p>
-            <p><strong>Price</strong> : <%= sock.price %></p>
+            <p><strong>Price</strong> : <%= sock.price.symbol %> <%= sock.price %></p>
             <button type="button" class="btn_small">  <%= link_to 'Show sock', sock_path(sock), method: :get%> </button>
             <button type="button" class="btn_small">  <%= link_to 'Edit sock', edit_sock_path(sock), method: :get%> </button>
             <br>
@@ -28,7 +28,7 @@
             <h3><strong>Textile</strong> : <%= sock.textile %></h3>
             <p><strong>Color</strong> : <%= sock.color %></p>
             <p><strong>Size</strong> : <%= sock.size %></p>
-            <p><strong>Price</strong> : <%= sock.price %></p>
+            <p><strong>Price</strong> : <%= sock.price.symbol %> <%= sock.price %></p>
             <button type="button" class="btn_small">  <%= link_to 'Show sock', sock_path(sock), method: :get%> </button>
             <br>
             <br>

--- a/app/views/socks/new.html.erb
+++ b/app/views/socks/new.html.erb
@@ -1,1 +1,2 @@
+<div class="container"><h3><b>Create your sock:</b></h3></div>
 <%= render 'shared/new_edit_sock', sock: @sock %>

--- a/app/views/socks/show.html.erb
+++ b/app/views/socks/show.html.erb
@@ -4,7 +4,7 @@
   <p><%= @sock.textile %></p>
   <p><%= @sock.color %></p>
   <p><%= @sock.size %></p>
-  <p><%= @sock.price %></p>
+  <p><%= @sock.price.symbol %> <%= @sock.price %></p>
   <% if user_signed_in? %>
     <% if @owner.id == current_user.id %>
       <p><button type="button" class="btn_small"> <%= link_to 'Edit sock', edit_sock_path(@sock), method: :get%> </button></p>

--- a/app/views/socks/show.html.erb
+++ b/app/views/socks/show.html.erb
@@ -5,11 +5,14 @@
   <p><%= @sock.color %></p>
   <p><%= @sock.size %></p>
   <p><%= @sock.price %></p>
-  <% if @owner.id == current_user.id %>
-  <p><%= link_to "Remove this sock from marketplace", status_hide_sock_path(@sock), method: :patch, data: { confirm: "Confirm removal of sock from marketplace" } %></p>
-  <% end %>
-  <% if @owner.id != current_user.id %>
-  <p><%= link_to "Purchase this wonderful piece of clothing", sock_bookings_path(@sock), method: :post, data: { confirm: "Confirm acquisition of item" } %></p>
+  <% if user_signed_in? %>
+    <% if @owner.id == current_user.id %>
+      <p><button type="button" class="btn_small"> <%= link_to 'Edit sock', edit_sock_path(@sock), method: :get%> </button></p>
+      <p><button type="button" class="btn_small"> <%= link_to "Remove this sock from marketplace", status_hide_sock_path(@sock), method: :patch, data: { confirm: "Confirm removal of sock from marketplace" } %> </button></p>
+    <% end %>
+    <% if @owner.id != current_user.id %>
+      <p><%= link_to "Purchase this wonderful piece of clothing", sock_bookings_path(@sock), method: :post, data: { confirm: "Confirm acquisition of item" } %></p>
+    <% end %>
   <% end %>
   <p><%= link_to 'Back to all socks', socks_path, method: :get%> </p>
 </div>

--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,0 +1,115 @@
+# encoding : utf-8
+
+MoneyRails.configure do |config|
+
+  # To set the default currency
+  #
+   config.default_currency = :eur
+
+  # Set default bank object
+  #
+  # Example:
+  # config.default_bank = EuCentralBank.new
+
+  # Add exchange rates to current money bank object.
+  # (The conversion rate refers to one direction only)
+  #
+  # Example:
+  # config.add_rate "USD", "CAD", 1.24515
+  # config.add_rate "CAD", "USD", 0.803115
+
+  # To handle the inclusion of validations for monetized fields
+  # The default value is true
+  #
+  # config.include_validations = true
+
+  # Default ActiveRecord migration configuration values for columns:
+  #
+  # config.amount_column = { prefix: '',           # column name prefix
+  #                          postfix: '_cents',    # column name  postfix
+  #                          column_name: nil,     # full column name (overrides prefix, postfix and accessor name)
+  #                          type: :integer,       # column type
+  #                          present: true,        # column will be created
+  #                          null: false,          # other options will be treated as column options
+  #                          default: 0
+  #                        }
+  #
+  # config.currency_column = { prefix: '',
+  #                            postfix: '_currency',
+  #                            column_name: nil,
+  #                            type: :string,
+  #                            present: true,
+  #                            null: false,
+  #                            default: 'USD'
+  #                          }
+
+  # Register a custom currency
+  #
+  # Example:
+  # config.register_currency = {
+  #   priority:            1,
+  #   iso_code:            "EU4",
+  #   name:                "Euro with subunit of 4 digits",
+  #   symbol:              "€",
+  #   symbol_first:        true,
+  #   subunit:             "Subcent",
+  #   subunit_to_unit:     10000,
+  #   thousands_separator: ".",
+  #   decimal_mark:        ","
+  # }
+
+  # Specify a rounding mode
+  # Any one of:
+  #
+  # BigDecimal::ROUND_UP,
+  # BigDecimal::ROUND_DOWN,
+  # BigDecimal::ROUND_HALF_UP,
+  # BigDecimal::ROUND_HALF_DOWN,
+  # BigDecimal::ROUND_HALF_EVEN,
+  # BigDecimal::ROUND_CEILING,
+  # BigDecimal::ROUND_FLOOR
+  #
+  # set to BigDecimal::ROUND_HALF_EVEN by default
+  #
+  # config.rounding_mode = BigDecimal::ROUND_HALF_UP
+
+  # Set default money format globally.
+  # Default value is nil meaning "ignore this option".
+  # Example:
+  #
+  config.default_format = {
+  #   no_cents_if_whole: nil,
+      symbol: "€",
+  #   sign_before_symbol: nil
+  }
+
+  # If you would like to use I18n localization (formatting depends on the
+  # locale):
+  # config.locale_backend = :i18n
+  #
+  # Example (using default localization from rails-i18n):
+  #
+  # I18n.locale = :en
+  # Money.new(10_000_00, 'USD').format # => $10,000.00
+  # I18n.locale = :es
+  # Money.new(10_000_00, 'USD').format # => $10.000,00
+  #
+  # For the legacy behaviourrails g money_rails:initializer of "per currency" localization (formatting depends
+  # only on currency):
+  # config.locale_backend = :currency
+  #
+  # Example:
+  # Money.new(10_000_00, 'USD').rails g money_rails:initializerformat # => $10,000.00
+  # Money.new(10_000_00, 'EUR').format # => €10.000,00
+  #
+  # In case you don't need localization and would like to use default values
+  # (can be redefined using config.default_format):
+  # config.locale_backend = nil
+
+  # Set default raise_error_on_money_parsing option
+  # It will be raise error if assigned different currency
+  # The default value is false
+  #
+  # Example:
+  # config.raise_error_on_money_parsing = false
+end

--- a/db/migrate/20200114193455_create_socks.rb
+++ b/db/migrate/20200114193455_create_socks.rb
@@ -2,7 +2,7 @@ class CreateSocks < ActiveRecord::Migration[5.2]
   def change
     create_table :socks do |t|
       t.integer :size
-      t.integer :price
+      t.monetize :price, currency: { present: false }, amount: { null: false, default: 0 }
       t.string :textile
       t.string :color
       t.references :user, foreign_key: true

--- a/db/migrate/20200118172901_add_funds_to_user.rb
+++ b/db/migrate/20200118172901_add_funds_to_user.rb
@@ -1,5 +1,0 @@
-class AddFundsToUser < ActiveRecord::Migration[5.2]
-  def change
-    add_column :users, :funds, :integer, :default => 10000
-  end
-end

--- a/db/migrate/20200118172901_add_funds_to_user.rb
+++ b/db/migrate/20200118172901_add_funds_to_user.rb
@@ -1,5 +1,5 @@
 class AddFundsToUser < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :funds, :integer, :default => 100
+    add_column :users, :funds, :integer, :default => 10000
   end
 end

--- a/db/migrate/20200120092526_user_funds_update.rb
+++ b/db/migrate/20200120092526_user_funds_update.rb
@@ -1,0 +1,5 @@
+class UserFundsUpdate < ActiveRecord::Migration[5.2]
+  def change
+    change_column :users, :funds, :integer, :default => 10000
+  end
+end

--- a/db/migrate/20200120092526_user_funds_update.rb
+++ b/db/migrate/20200120092526_user_funds_update.rb
@@ -1,5 +1,0 @@
-class UserFundsUpdate < ActiveRecord::Migration[5.2]
-  def change
-    change_column :users, :funds, :integer, :default => 10000
-  end
-end

--- a/db/migrate/20200120125428_add_monetize_funds_to_user.rb
+++ b/db/migrate/20200120125428_add_monetize_funds_to_user.rb
@@ -1,0 +1,5 @@
+class AddMonetizeFundsToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_monetize :users, :funds, currency: { present: false }, amount: { null: false, default: 10000 }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_20_092526) do
+ActiveRecord::Schema.define(version: 2020_01_20_125428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2020_01_20_092526) do
 
   create_table "socks", force: :cascade do |t|
     t.integer "size"
-    t.integer "price"
+    t.integer "price_cents", default: 0, null: false
     t.string "textile"
     t.string "color"
     t.bigint "user_id"
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2020_01_20_092526) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "funds", default: 10000
+    t.integer "funds_cents", default: 10000, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_18_172901) do
+ActiveRecord::Schema.define(version: 2020_01_20_092526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2020_01_18_172901) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "funds", default: 100
+    t.integer "funds", default: 10000
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Installed 'money-rails'-Gem to handle currency (User funds and Sock prices). Replaced database attributes for these with new objects: Money - which handles the euro/cent issue and disallows the use of floats for our attributes. Documentation: https://github.com/RubyMoney/money-rails
Also has a few inbuilt methods to display currency type to allow for potential ease of cross-currency use (when we are bought by Google).

I've had to update the migration for Socks and add a new attribute to Users, so it is possible that we will have to drop the production DB and re-apply it to reflect this. I could have done it all with migration upon migration but frankly it became too spaghetti for my liking, since our production is still just a test.

Also updated the navbar to show user email and current currency amount (no layout changes, just new display objects).

I tested this fairly extensively, but pls review and let me know if you find issues :) If you trust this, please confirm the pull.
